### PR TITLE
Added functionality to Hint button + game logic changes 

### DIFF
--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -1,17 +1,19 @@
-import React from 'react';
-import styles from './Footer.module.css';
-import Button from '../Button/Button';
+import { useNavigate } from "react-router-dom";
+import Button from "../Button/Button";
+import styles from "./Footer.module.css";
 
 function Footer() {
+  const navigate = useNavigate();
+
   return (
     <div className={styles.footerContainer}>
       <footer className={styles.buttonContainer}>
-        <Button>Start</Button>
+        <Button onClick={() => navigate("/gamescreen")}>Start</Button>
         <Button>Pop Quiz</Button>
         <Button>Library</Button>
       </footer>
     </div>
   );
 }
-  
-  export default Footer; 
+
+export default Footer;

--- a/src/Components/GameScreen/GameScreen.jsx
+++ b/src/Components/GameScreen/GameScreen.jsx
@@ -1,13 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import styles from './GameScreen.module.css';
-import Button from '../Button/Button';
-import Map from '../Map/Map';
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styles from "./GameScreen.module.css";
+import Button from "../Button/Button";
+import Map from "../Map/Map";
 
 function GameScreen() {
   const [stateData, setStateData] = useState([]);
-  const [isGameStarted, setIsGameStarted] = useState(false);
   const [currentState, setCurrentState] = useState(null);
   const [clickedStates, setClickedStates] = useState({});
+  const [hint, setHint] = useState("");
+  const [hintStep, setHintStep] = useState(0);
+
+  const navigate = useNavigate();
 
   // Fetch state data once
   useEffect(() => {
@@ -17,8 +21,10 @@ function GameScreen() {
           "https://parseapi.back4app.com/classes/States?limit=50&order=name",
           {
             headers: {
-              "X-Parse-Application-Id": "6a2NWTwXRlwc1BynCf46kYZG1VeWp170GYjZIeXK",
-              "X-Parse-Master-Key": "WEYdiGWSz0gt91skfDe03wX9yqikQTpiVc9Vn2An",
+              "X-Parse-Application-Id":
+                "6a2NWTwXRlwc1BynCf46kYZG1VeWp170GYjZIeXK",
+              "X-Parse-Master-Key":
+                "WEYdiGWSz0gt91skfDe03wX9yqikQTpiVc9Vn2An",
             },
           }
         );
@@ -31,43 +37,83 @@ function GameScreen() {
     fetchStates();
   }, []);
 
+  // Start game automatically once data is loaded
+  useEffect(() => {
+    if (stateData.length > 0) {
+      generateRandomCapital();
+    }
+  }, [stateData]);
+
   const generateRandomCapital = () => {
+    if (stateData.length === 0) return;
     const randomIndex = Math.floor(Math.random() * stateData.length);
     setCurrentState(stateData[randomIndex]);
-    setIsGameStarted(true);
     setClickedStates({});
+    setHint(""); // reset hint text
+    setHintStep(0);
   };
 
   const handleStateClick = (clickedState) => {
     if (!currentState) return;
 
     if (clickedState.name === currentState.name) {
-      setClickedStates((prev) => ({ ...prev, [clickedState.postalAbreviation]: "correct" }));
+      setClickedStates((prev) => ({
+        ...prev,
+        [clickedState.postalAbreviation]: "correct",
+      }));
       setTimeout(generateRandomCapital, 1200);
     } else {
-      setClickedStates((prev) => ({ ...prev, [clickedState.postalAbreviation]: "wrong" }));
+      setClickedStates((prev) => ({
+        ...prev,
+        [clickedState.postalAbreviation]: "wrong",
+      }));
     }
   };
 
-  return(
-    <div>
-     <header className={styles.headerContainer}>
-      <Button>Menu</Button>
-      <Button onClick={generateRandomCapital}>Start Game</Button>
-      <Button onClick={() => setIsGameStarted(false)}>Quit</Button>
+  const generateHint = () => {
+    if (!currentState) return;
 
-      {isGameStarted && currentState && (
-      <div className={styles.capitalBox}>
-        {currentState.capital}
-      </div>
-  )}
-    </header>
+    let hintMessage = "";
+
+    switch (hintStep) {
+      case 0:
+        hintMessage = `The state starts with "${currentState.name.charAt(0)}".`;
+        break;
+      case 1:
+        hintMessage = `Its abbreviation is "${currentState.postalAbreviation}".`;
+        break;
+      case 2:
+        hintMessage = `The largest city is ${currentState.largestCity}.`;
+        break;
+      default:
+        hintMessage = "No more hints available!";
+        break;
+    }
+
+    setHint(hintMessage);
+    setHintStep((prev) => prev + 1);
+  };
+
+  return (
+    <div>
+      <header className={styles.headerContainer}>
+        {currentState && (
+          <div className={styles.capitalBox}>{currentState.capital}</div>
+        )}
+
+        <Button>Menu</Button>
+        <Button onClick={() => navigate("/")}>Quit</Button>
+      </header>
 
       <Map onStateClick={handleStateClick} clickedStates={clickedStates} />
-     <Button className={styles.hintButton}>Hint</Button>
+
+      <Button className={styles.hintButton} onClick={generateHint}>
+        Hint
+      </Button>
+
+      {hint && <div className={styles.hintBox}>{hint}</div>}
     </div>
   );
 }
-
 
 export default GameScreen;

--- a/src/Components/HomePage/HomePage.jsx
+++ b/src/Components/HomePage/HomePage.jsx
@@ -1,29 +1,33 @@
-import React, { useState } from 'react';
-import Map from '../Map/Map';
-import Modal from '../Modal/Modal'; // adjust import path to your modal
-import Header from '../Header/Header';
-import Footer from '../Footer/Footer';
+import React, { useState } from "react";
+import Header from "../Header/Header";
+import Footer from "../Footer/Footer";
+import Map from "../Map/Map";
+import Modal from "../Modal/Modal";
+import GameScreen from "../GameScreen/GameScreen";
 
 function HomePage() {
   const [selectedState, setSelectedState] = useState(null);
+  const [isGameScreen, setIsGameScreen] = useState(false);
 
-  const handleStateClick = (state) => {
-    setSelectedState(state); // pass the whole state object from Map
-  };
-
-  const closeModal = () => setSelectedState(null);
+  const handleStartGame = () => setIsGameScreen(true);
+  const handleQuitGame = () => setIsGameScreen(false);
 
   return (
     <>
-    <Header/>
-      <Map onStateClick={handleStateClick} />
-
-      <Modal 
-        isOpen={!!selectedState} 
-        onClose={closeModal} 
-        selectedState={selectedState} 
-      />
-    <Footer/>
+      <Header />
+      {!isGameScreen ? (
+        <>
+          <Map onStateClick={setSelectedState} />
+          <Modal
+            isOpen={!!selectedState}
+            onClose={() => setSelectedState(null)}
+            selectedState={selectedState}
+          />
+          <Footer onStart={handleStartGame} />
+        </>
+      ) : (
+        <GameScreen onQuit={handleQuitGame} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
Hint button now displays three hints per capital. 
Next steps: Keep hints displayed for the user 

Changed the logic of the game a bit.
The 'Start' button on the home page now starts the game and directs to the /gamescreen page 
Next Steps: have Quit button direct to results page then have option to go home and menu

Key Changes: 
Removed isGameStarted (since starting is handled by routing).

Added useEffect to auto-start game when stateData loads.

Quit button now calls navigate("/") to go back home.

Removed “Start Game” button from inside GameScreen since navigation already starts it.


