### PR TITLE
Hints remain visible to users 

### DIFF
--- a/src/Components/GameScreen/GameScreen.jsx
+++ b/src/Components/GameScreen/GameScreen.jsx
@@ -8,7 +8,7 @@ function GameScreen() {
   const [stateData, setStateData] = useState([]);
   const [currentState, setCurrentState] = useState(null);
   const [clickedStates, setClickedStates] = useState({});
-  const [hint, setHint] = useState("");
+  const [hint, setHint] = useState([]);
   const [hintStep, setHintStep] = useState(0);
 
   const navigate = useNavigate();
@@ -49,7 +49,7 @@ function GameScreen() {
     const randomIndex = Math.floor(Math.random() * stateData.length);
     setCurrentState(stateData[randomIndex]);
     setClickedStates({});
-    setHint(""); // reset hint text
+    setHint([]); // reset hint text
     setHintStep(0);
   };
 
@@ -89,9 +89,12 @@ function GameScreen() {
         hintMessage = "No more hints available!";
         break;
     }
-
-    setHint(hintMessage);
-    setHintStep((prev) => prev + 1);
+    if (hintStep < 3) {
+     setHint((prev) => [...prev, hintMessage]); // append instead of replace
+     setHintStep((prev) => prev + 1);
+    }  else {
+     setHint((prev) => [...prev, hintMessage]); // show "no more hints"
+    }
   };
 
   return (
@@ -111,7 +114,14 @@ function GameScreen() {
         Hint
       </Button>
 
-      {hint && <div className={styles.hintBox}>{hint}</div>}
+      {hint.length > 0 && (
+        <div className={styles.hintBox}>
+          {hint.map((h, index) => (
+            <div key={index}>{h}</div>
+          ))}
+        </div>
+      )}
+
     </div>
   );
 }

--- a/src/Components/HomePage/HomePage.jsx
+++ b/src/Components/HomePage/HomePage.jsx
@@ -8,7 +8,6 @@ import GameScreen from "../GameScreen/GameScreen";
 function HomePage() {
   const [selectedState, setSelectedState] = useState(null);
   const [isGameScreen, setIsGameScreen] = useState(false);
-
   const handleStartGame = () => setIsGameScreen(true);
   const handleQuitGame = () => setIsGameScreen(false);
 


### PR DESCRIPTION
All three hints remain visible to the user. 
Each time the user clicks "Hint," a new hint appears under the previous ones.
When the player guesses correctly and a new capital is loaded, the hints clear out and restart fresh.
This allows users to refer back to the hint messages if they still need help. 

To Do: 
UI for hint box 

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/de3952c9-b1f1-4ced-b22b-0c85d718de1a" />
